### PR TITLE
FIX: logic for is_low is wrong

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -576,7 +576,7 @@ impl<const P: char, const N: u8, MODE> Pin<P, N, MODE> {
     fn _is_low(&self) -> bool {
         // NOTE(unsafe) atomic read with no side effects
         let gpio = unsafe { &(*gpiox::<P>()) };
-        gpio.idr.read().bits() & (1 << N) != 0
+        gpio.idr.read().bits() & (1 << N) == 0
     }
 }
 


### PR DESCRIPTION
The problem is obviously.
The & operator fetches the nth bit, and if it  ==0 , it is low.
I have checked the logic with real circuit, it works.