### PR TITLE
FIX pwm release logic and split logic

### DIFF
--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -23,8 +23,8 @@ fn main() -> ! {
         gpioa.pa9.into_alternate_af2(), // on TIM1_CH2
     );
 
-    let pwm = dp.TIM1.pwm_hz(channels, 20.kHz(), &rcc.clocks);
-    let (mut ch1, mut ch2) = pwm.split();
+    let mut pwm = dp.TIM1.pwm_hz(channels, 20.kHz(), &rcc.clocks);
+    let (ref mut ch1, ref mut ch2) = pwm.channels();
     let max_duty = ch1.get_max_duty();
     ch1.set_duty(max_duty / 4);
     ch1.enable();

--- a/examples/pwm_complementary.rs
+++ b/examples/pwm_complementary.rs
@@ -26,8 +26,8 @@ fn main() -> ! {
         gpioa.pa7.into_alternate_af2(), // on TIM1_CH1N
     );
 
-    let pwm = dp.TIM1.pwm_hz(channels, 20.kHz(), &rcc.clocks);
-    let (mut ch1, mut ch1n) = pwm.split();
+    let mut pwm = dp.TIM1.pwm_hz(channels, 20.kHz(), &rcc.clocks);
+    let (ref mut ch1, ref mut ch1n) = pwm.channels();
     let max_duty = ch1.get_max_duty();
     ch1.set_duty(max_duty / 2);
     ch1.enable();


### PR DESCRIPTION
This approach uses the release() @gpgreen mentioned earlier in https://github.com/py32-rust/py32f0xx-hal/issues/8 

This PR remove the split() and replace it with channels() which returns mutable references to channels.

This ensures the lifetime of the returned mutable reference doesn't exceed that of PwmHz.

This PR also changed stuff which release() function's returned, to support reconstruct a PwmHz again.

I have tested this approach on my embedded device, it works.

@gpgreen 
Could you please review and confirm if this solution is acceptable?